### PR TITLE
Log git hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ var (
 ```
 
 Then run `go generate` to create the `docker-run.sh` file from your JSON config file.
+
+The log prefix is set to the executable name.  The an additional string can optionally be appended to the prefix by setting cfg.Build
+at compile time e.g.,
+
+```
+ ... -ldflags "-X github.com/GeoNet/cfg.Build `git rev-parse --short HEAD`" ...
+ ```

--- a/cfg.go
+++ b/cfg.go
@@ -81,7 +81,7 @@ type HeartBeat struct {
 
 type SC3 struct {
 	SpoolDir string `doc:"Spool directory for SeisComPML files." env:"${PREFIX}_SC3_SPOOL_DIR"`
-	Site     string `doc:"The SC3 site - primary or backup." env:${PREFIX}_SC3_SITE"`
+	Site     string `doc:"The SC3 site - primary or backup." env:"${PREFIX}_SC3_SITE"`
 }
 
 type Librato struct {

--- a/cfg.go
+++ b/cfg.go
@@ -15,6 +15,9 @@ import (
 // the directory to look for config override files in.
 var over = "/etc/sysconfig"
 
+// compile passing -ldflags "-X github.com/GeoNet/cfg.Build <build sha1>"
+var Build string
+
 type Config struct {
 	DataBase   *DataBase
 	WebServer  *WebServer
@@ -196,7 +199,7 @@ func (c *Config) env() {
 func Load() Config {
 	a := strings.Split(os.Args[0], "/")
 	name := a[len(a)-1]
-	log.SetPrefix(name + " ")
+	log.SetPrefix(name + Build + " ")
 
 	c := name + ".json"
 	ov := over + "/" + c


### PR DESCRIPTION
Adds an option to compile in the current Git short treeish (or any other string) during build.  This is then added to the log prefix.